### PR TITLE
Enhance tree‑sitter Verilog parser

### DIFF
--- a/backend/runParser.mjs
+++ b/backend/runParser.mjs
@@ -1,0 +1,19 @@
+import { Worker } from 'worker_threads';
+import path from 'path';
+import fs from 'fs';
+
+const files = process.argv.slice(2).map(f => path.resolve(f));
+const worker = new Worker(new URL('./workers/parseWorker.mjs', import.meta.url), {
+  workerData: { files }
+});
+
+worker.on('message', (graph) => {
+  fs.writeFileSync('design_hierarchy.json', JSON.stringify(graph, null, 2), 'utf8');
+  console.log('Parsed', graph.length, 'modules');
+});
+worker.on('error', (err) => {
+  console.error('Worker error:', err);
+});
+worker.on('exit', (code) => {
+  if (code !== 0) console.error('Worker exited with code', code);
+});

--- a/design_hierarchy.json
+++ b/design_hierarchy.json
@@ -1,211 +1,65 @@
 [
   {
-    "module": "FPADD",
-    "file": "FPADD.v",
+    "module": "M",
+    "file": "ansi_example.v",
+    "ports": [
+      {
+        "name": "clk",
+        "direction": "input",
+        "width": "1",
+        "type": "wire",
+        "style": "ansi"
+      },
+      {
+        "name": "data",
+        "direction": "output",
+        "width": "31:0",
+        "type": "wire",
+        "style": "ansi"
+      }
+    ],
+    "instances": [],
+    "parameters": [],
+    "range": {
+      "start": 0,
+      "end": 4
+    }
+  },
+  {
+    "module": "top",
+    "file": "instance_example.v",
     "ports": [],
     "instances": [],
     "parameters": [],
     "range": {
       "start": 0,
-      "end": 214
+      "end": 3
     }
   },
   {
-    "module": "exponentAdder",
-    "file": "FPADD.v",
-    "ports": [],
-    "instances": [],
-    "parameters": [],
-    "range": {
-      "start": 217,
-      "end": 255
-    }
-  },
-  {
-    "module": "PSL",
-    "file": "FPADD.v",
-    "ports": [],
-    "instances": [],
-    "parameters": [],
-    "range": {
-      "start": 258,
-      "end": 279
-    }
-  },
-  {
-    "module": "alignAsb",
-    "file": "FPADD.v",
-    "ports": [],
-    "instances": [],
-    "parameters": [],
-    "range": {
-      "start": 282,
-      "end": 334
-    }
-  },
-  {
-    "module": "significandSelectroMux",
-    "file": "FPADD.v",
-    "ports": [],
-    "instances": [],
-    "parameters": [],
-    "range": {
-      "start": 338,
-      "end": 361
-    }
-  },
-  {
-    "module": "significandAdder",
-    "file": "FPADD.v",
-    "ports": [],
-    "instances": [],
-    "parameters": [],
-    "range": {
-      "start": 364,
-      "end": 421
-    }
-  },
-  {
-    "module": "Sign",
-    "file": "FPADD.v",
-    "ports": [],
-    "instances": [],
-    "parameters": [],
-    "range": {
-      "start": 424,
-      "end": 442
-    }
-  },
-  {
-    "module": "psl_one",
-    "file": "FPADD.v",
-    "ports": [],
-    "instances": [],
-    "parameters": [],
-    "range": {
-      "start": 445,
-      "end": 483
-    }
-  },
-  {
-    "module": "GRS",
-    "file": "FPADD.v",
-    "ports": [],
-    "instances": [],
-    "parameters": [],
-    "range": {
-      "start": 486,
-      "end": 519
-    }
-  },
-  {
-    "module": "sumResultSelector",
-    "file": "FPADD.v",
-    "ports": [],
-    "instances": [],
-    "parameters": [],
-    "range": {
-      "start": 521,
-      "end": 547
-    }
-  },
-  {
-    "module": "Sf_add",
-    "file": "FPADD.v",
-    "ports": [],
-    "instances": [],
-    "parameters": [],
-    "range": {
-      "start": 549,
-      "end": 564
-    }
-  },
-  {
-    "module": "OneCom",
-    "file": "FPADD.v",
-    "ports": [],
-    "instances": [],
-    "parameters": [],
-    "range": {
-      "start": 567,
-      "end": 584
-    }
-  },
-  {
-    "module": "LOP",
-    "file": "FPADD.v",
-    "ports": [],
-    "instances": [],
-    "parameters": [],
-    "range": {
-      "start": 587,
-      "end": 611
-    }
-  },
-  {
-    "module": "ExpAdj",
-    "file": "FPADD.v",
-    "ports": [],
-    "instances": [],
-    "parameters": [],
-    "range": {
-      "start": 614,
-      "end": 657
-    }
-  },
-  {
-    "module": "normalizationShift",
-    "file": "FPADD.v",
-    "ports": [],
-    "instances": [],
-    "parameters": [],
-    "range": {
-      "start": 660,
-      "end": 675
-    }
-  },
-  {
-    "module": "resultSelector",
-    "file": "FPADD.v",
-    "ports": [],
-    "instances": [],
-    "parameters": [],
-    "range": {
-      "start": 678,
-      "end": 693
-    }
-  },
-  {
-    "module": "FPMULDIV",
-    "file": "FPMULDIV.v",
-    "ports": [],
-    "instances": [],
-    "parameters": [],
-    "range": {
-      "start": 1,
-      "end": 95
-    }
-  },
-  {
-    "module": "LUT",
-    "file": "LUT.v",
-    "ports": [],
-    "instances": [],
-    "parameters": [],
-    "range": {
-      "start": 1,
-      "end": 81
-    }
-  },
-  {
-    "module": "MANT_MUL_DIV",
-    "file": "MANT_MUL_DIV.v",
-    "ports": [],
+    "module": "M",
+    "file": "legacy_example.v",
+    "ports": [
+      {
+        "name": "clk",
+        "direction": "input",
+        "width": "1",
+        "type": "wire",
+        "style": "traditional"
+      },
+      {
+        "name": "data",
+        "direction": "output",
+        "width": "31:0",
+        "type": "wire",
+        "style": "traditional"
+      }
+    ],
     "instances": [],
     "parameters": [],
     "range": {
       "start": 0,
-      "end": 76
+      "end": 4
     }
   }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,9 @@
         "lucide-svelte": "^0.513.0",
         "monaco-editor": "^0.52.2",
         "node-fetch": "^3.3.2",
-        "tree-sitter": "^0.25.0"
+        "tree-sitter": "^0.25.0",
+        "tree-sitter-verilog": "^1.0.0",
+        "web-tree-sitter": "^0.25.6"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^5.0.3",
@@ -1567,6 +1569,12 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/nan": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
+      "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -2099,6 +2107,16 @@
         "node-gyp-build": "^4.8.4"
       }
     },
+    "node_modules/tree-sitter-verilog": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-verilog/-/tree-sitter-verilog-1.0.0.tgz",
+      "integrity": "sha512-SSGUwA+mQ1Jxn/V2ROLj3+leO/68f+7MxWzoz5kOaJ3qzKAveSWjxOATGmiFMLy4DJ+/0pDXFnapwMDih2Cx6Q==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "nan": "^2.15.0"
+      }
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -2233,6 +2251,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.25.6.tgz",
+      "integrity": "sha512-WG+/YGbxw8r+rLlzzhV+OvgiOJCWdIpOucG3qBf3RCBFMkGDb1CanUi2BxCxjnkpzU3/hLWPT8VO5EKsMk9Fxg==",
+      "license": "MIT"
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "lucide-svelte": "^0.513.0",
     "monaco-editor": "^0.52.2",
     "node-fetch": "^3.3.2",
-    "tree-sitter": "^0.25.0"
+    "tree-sitter": "^0.25.0",
+    "tree-sitter-verilog": "^1.0.0",
+    "web-tree-sitter": "^0.25.6"
   }
 }

--- a/verilog_samples/ansi_example.v
+++ b/verilog_samples/ansi_example.v
@@ -1,0 +1,5 @@
+module M (
+  input wire clk,
+  output reg [31:0] data
+);
+endmodule

--- a/verilog_samples/instance_example.v
+++ b/verilog_samples/instance_example.v
@@ -1,0 +1,4 @@
+module top;
+  clock_gen U1 (.clk(sys_clk), .rst(1'b0));
+  adder #(.WIDTH(32)) add1 (a, b, sum);
+endmodule

--- a/verilog_samples/legacy_example.v
+++ b/verilog_samples/legacy_example.v
@@ -1,0 +1,5 @@
+module M (clk, data);
+  input clk;
+  output [31:0] data;
+  reg [31:0] data;
+endmodule


### PR DESCRIPTION
## Summary
- use `web-tree-sitter` with the Verilog WASM grammar
- update dependencies
- produce example design hierarchy using WASM parser

## Testing
- `node backend/runParser.mjs verilog_samples/*.v`

------
https://chatgpt.com/codex/tasks/task_e_68492c211cfc8329bc4d1d0180742bef